### PR TITLE
Match new calculation methodology

### DIFF
--- a/sow/scripts/calculations.py
+++ b/sow/scripts/calculations.py
@@ -1,5 +1,6 @@
 from decimal import Decimal, ROUND_UP
 from datetime import date
+from math import floor
 
 from dateutil.relativedelta import relativedelta
 from workalendar.europe import UnitedKingdom
@@ -17,13 +18,20 @@ def calculate_number_of_payments(number_of_months, number_of_days):
     return number_of_months
 
 
-def calculate_working_days(parsed_start, parsed_end):
-    return calendar.get_working_days_delta(
-        # need to move start date back one day as the
-        # get_working_day_delta calculation doesn't include the first day.
-        # A simple +1 wouldn't work if the first day is a holiday.
-        parsed_start + relativedelta(days=-1),
-        parsed_end,
+def calculate_working_days(parsed_start, parsed_end, number_of_months):
+    set_days_off_per_month = 1.6666666666666667
+    days_of = number_of_months * set_days_off_per_month
+    return floor(
+        (
+            calendar.get_working_days_delta(
+                # need to move start date back one day as the
+                # get_working_day_delta calculation doesn't include the first day.
+                # A simple +1 wouldn't work if the first day is a holiday.
+                parsed_start + relativedelta(days=-1),
+                parsed_end,
+            )
+            - days_of
+        )
     )
 
 

--- a/sow/scripts/generate_statement_of_works.py
+++ b/sow/scripts/generate_statement_of_works.py
@@ -44,7 +44,9 @@ def generate_statement_of_works(
     contract_length = calculate_contract_duration(
         parsed_start_date, parsed_end_date
     )
-    working_days = calculate_working_days(parsed_start_date, parsed_end_date)
+    working_days = calculate_working_days(
+        parsed_start_date, parsed_end_date, contract_length.months
+    )
     contract_fee = calculate_contract_fee(day_rate, working_days)
     retention_fee = calculate_retention_fee(contract_fee)
     contract_end_month = parsed_end_date.strftime('%B')

--- a/sow/scripts/test_calculations.py
+++ b/sow/scripts/test_calculations.py
@@ -33,15 +33,21 @@ def test_calculate_number_of_payments(a, b, expected):
     assert calculate_number_of_payments(a, b) == expected
 
 
-def test_calculate_working_days():
+@pytest.mark.parametrize(
+    "a, b, c, expected",
+    [
+        (parse('2020-01-01'), parse('2020-03-31'), 3, 59),
+        (parse('2020-01-01'), parse('2020-06-30'), 6, 115),
+        (parse('2020-01-01'), parse('2020-05-31'), 5, 94),
+    ],
+)
+def test_calculate_working_days(a, b, c, expected):
     """
     Test the calculation of working days. It should move the start date back
     by one because the working days calculation doesn't
     include the first day by default.
     """
-    assert (
-        calculate_working_days(parse('2020-01-01'), parse('2020-03-31')) == 64
-    )
+    assert calculate_working_days(a, b, c) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The calculation for working days has changed. Now 10 days per 6 months (pro rated) is taken off of the total working days. 