### PR TITLE
Set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    assignees:
+      day: "monday"
+    reviewers:
       - "cgsunkel"
   
   #Backend updates
@@ -18,6 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    assignees:
+      day: "monday"
+    reviewers:
       - "cgsunkel"
       

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  #Frontend updates
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    default_reviewers:
+      - "cgsunkel"
+  
+  #Backend updates
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    default_reviewers:
+      - "cgsunkel"
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
-    default_reviewers:
+    assignees:
       - "cgsunkel"
   
   #Backend updates
@@ -18,6 +18,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    default_reviewers:
+    assignees:
       - "cgsunkel"
       


### PR DESCRIPTION
After the recent Django security incident I have set up Dependabot for this repo. For now I've just set it up so everything to be assigned for me to approve, let me know if you want to be added as well. 

Note that the syntax in the YAML file is different to the Data Hub Dependabot configs as this is the new native version (docs are [here](https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates)) instead of the preview version that DH uses.